### PR TITLE
ISSUE-19 bsp-build-scripts: Dockerfile: add development packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -sf bash /bin/sh
 RUN echo "Installing dependencies"
 RUN DEBIAN_FRONTEND=noninteractive dpkg --add-architecture i386 \
     && apt -yqq update \
-    && apt-get install -yqq locales sudo
+    && apt-get install -yqq locales sudo vim bison flex exuberant-ctags
 
 # locales issue fix
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales \


### PR DESCRIPTION
Added additional packages to base Ubuntu image to reduce the need
to add them at a later time in the live contianer.

Signed-off-by: nmccarty <nmccarty@phytec.com>