### PR TITLE
PD-BSP-Yocto-FSL-i.MX8MM-ALPHA2.sh fails when Host OS is using a kernel

### DIFF
--- a/bsp-build-scripts/phycore-imx8m-mini/linux/PD-BSP-Yocto-FSL-i.MX8MM-ALPHA2.sh
+++ b/bsp-build-scripts/phycore-imx8m-mini/linux/PD-BSP-Yocto-FSL-i.MX8MM-ALPHA2.sh
@@ -60,6 +60,15 @@ repo init -u $MANIFEST_URL -b $MANIFEST_BRANCH -m $MANIFEST_FILE
 repo sync
 export PATH="$YOCTO_DIR/sources/oe-core/bitbake/bin:$PATH"
 
+#Apply fixups
+#ISSUE-#30 https://github.com/phytec-labs/peaks/issues/30
+#PD-BSP-Yocto-FSL-i.MX8MM-ALPHA2.sh fails when Host OS is using kernel > 4.15
+cd /home/$USER_NAME/PHYTEC_BSPs/$MANIFEST_BRANCH/$BSP_VERSION/sources/poky 
+curl -O "https://artifactory.phytec.com/artifactory/fixups/thud/poky/0001-wic-filemap-If-FIGETBSZ-iotctl-fail-failback-to-os.s.patch"
+git am 0001-wic-filemap-If-FIGETBSZ-iotctl-fail-failback-to-os.s.patch
+
+
+
 # set environment
 
 


### PR DESCRIPTION
version > 4.15. A patch is available here:
http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/scripts/lib/wic/filemap.py?id=b14588a77842f41613bd251165cce5bc95a708ad
We created a .patch and apply it in the build script to fix the issue.

Signed-off-by: Nick McCarty <mccartyn@gmail.com>